### PR TITLE
Feature/14/14 upgrade edc

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: 5191d3e6dd9ac5d78264d05ae69edb4d297b606a
+        ref: 1648d148651e63de9de8d7b21d474b80aa5a14ae
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,7 +3,6 @@ name: Test Code (Style, Tests)
 on:
   push:
   pull_request:
-    branches: [ main ]
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/manager/ParticipantManager.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.dataspaceconnector.registration.manager;
 
-import org.eclipse.dataspaceconnector.common.statemachine.StateMachine;
+import org.eclipse.dataspaceconnector.common.statemachine.StateMachineManager;
 import org.eclipse.dataspaceconnector.common.statemachine.StateProcessorImpl;
 import org.eclipse.dataspaceconnector.registration.authority.model.Participant;
 import org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus;
@@ -37,7 +37,7 @@ public class ParticipantManager {
     private final Monitor monitor;
     private final ParticipantStore participantStore;
     private final CredentialsVerifier credentialsVerifier;
-    private final StateMachine stateMachine;
+    private final StateMachineManager stateMachineManager;
 
     public ParticipantManager(Monitor monitor, ParticipantStore participantStore, CredentialsVerifier credentialsVerifier, ExecutorInstrumentation executorInstrumentation) {
         this.monitor = monitor;
@@ -48,7 +48,7 @@ public class ParticipantManager {
         WaitStrategy waitStrategy = () -> 5000L;
 
         // define state machine
-        stateMachine = StateMachine.Builder.newInstance("registration-service", monitor, executorInstrumentation, waitStrategy)
+        stateMachineManager = StateMachineManager.Builder.newInstance("registration-service", monitor, executorInstrumentation, waitStrategy)
                 .processor(processParticipantsInState(ONBOARDING_INITIATED, this::processOnboardingInitiated))
                 .processor(processParticipantsInState(AUTHORIZING, this::processAuthorizing))
                 .build();
@@ -58,14 +58,14 @@ public class ParticipantManager {
      * Start the participant manager state machine processor thread.
      */
     public void start() {
-        stateMachine.start();
+        stateMachineManager.start();
     }
 
     /**
      * Stop the participant manager state machine processor thread.
      */
     public void stop() {
-        stateMachine.stop();
+        stateMachineManager.stop();
     }
 
     private Boolean processOnboardingInitiated(Participant participant) {


### PR DESCRIPTION
## What this PR changes/adds

- Upgrade EDC version
- Run CI against target branches other than `main`, for fork PRs

## Why it does that

A second PR will be produced against this target branch. Split into 2 PRs for clarity: https://github.com/agera-edc/RegistrationService/pull/11

## Further notes

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
