### PR TITLE
Feature/14/14 participant did

### DIFF
--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
@@ -14,9 +14,6 @@
 
 package org.eclipse.dataspaceconnector.registration.cli;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.dataspaceconnector.registration.client.models.Participant;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
@@ -26,23 +23,15 @@ import java.util.concurrent.Callable;
 @Command(name = "add", description = "Add a participant to dataspace")
 class AddParticipantCommand implements Callable<Integer> {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     @ParentCommand
     private ParticipantsCommand command;
 
-    @CommandLine.Option(names = "--request", required = true, description = "Add Participant Request as JSON")
-    private String requestJson;
+    @CommandLine.Option(names = "--ids-url", required = true, description = "Participant IDS URL")
+    private String idsUrl;
 
     @Override
-    public Integer call() throws Exception {
-        Participant participant = null;
-        try {
-            participant = MAPPER.readValue(requestJson, Participant.class);
-        } catch (JsonProcessingException e) {
-            throw new CliException("Error while processing request json.");
-        }
-        command.cli.registryApiClient.addParticipant(participant);
+    public Integer call() {
+        command.cli.registryApiClient.addParticipant(idsUrl);
 
         return 0;
     }

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
@@ -31,7 +31,7 @@ class AddParticipantCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        command.cli.registryApiClient.addParticipant(idsUrl);
+        command.cli.registryApiClient.addParticipant(command.cli.clientDid, idsUrl);
 
         return 0;
     }

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/AddParticipantCommand.java
@@ -31,7 +31,7 @@ class AddParticipantCommand implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        command.cli.registryApiClient.addParticipant(command.cli.clientDid, idsUrl);
+        command.cli.registryApiClient.addParticipant(idsUrl, command.cli.clientDid);
 
         return 0;
     }

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
@@ -28,6 +28,9 @@ public class RegistrationServiceCli {
     @CommandLine.Option(names = "-s", required = true, description = "Registration service URL", defaultValue = "http://localhost:8181/api")
     String service;
 
+    @CommandLine.Option(names = "-d", required = true, description = "Client DID")
+    String clientDid;
+
     RegistryApi registryApiClient;
 
     public static void main(String... args) {
@@ -50,6 +53,5 @@ public class RegistrationServiceCli {
     private void init() {
         var apiClient = ApiClientFactory.createApiClient(service);
         registryApiClient = new RegistryApi(apiClient);
-
     }
 }

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
@@ -21,7 +21,6 @@ import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
 import org.eclipse.dataspaceconnector.registration.client.models.Participant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import picocli.CommandLine;
 
 import java.io.PrintWriter;
@@ -30,8 +29,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.registration.cli.TestUtils.createParticipant;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,6 +41,7 @@ class ParticipantsCommandTest {
     Participant participant1 = createParticipant();
     Participant participant2 = createParticipant();
     String serverUrl = FAKER.internet().url();
+    String idsUrl = FAKER.internet().url();
 
     RegistrationServiceCli app = new RegistrationServiceCli();
     CommandLine cmd = new CommandLine(app);
@@ -61,7 +59,7 @@ class ParticipantsCommandTest {
         when(app.registryApiClient.listParticipants())
                 .thenReturn(participants);
 
-        var exitCode = cmd.execute("-s", serverUrl, "participants", "list");
+        var exitCode = executeParticipantsAdd();
         assertThat(exitCode).isEqualTo(0);
         assertThat(serverUrl).isEqualTo(app.service);
 
@@ -73,27 +71,28 @@ class ParticipantsCommandTest {
     }
 
     @Test
-    void add() throws Exception {
-        var participantArgCaptor = ArgumentCaptor.forClass(Participant.class);
-        doNothing().when(app.registryApiClient).addParticipant(participantArgCaptor.capture());
-        var request = MAPPER.writeValueAsString(participant1);
-
-        var exitCode = cmd.execute("-s", serverUrl, "participants", "add", "--request", request);
+    void add() {
+        var exitCode = executeParticipantsAdd(idsUrl);
 
         assertThat(exitCode).isEqualTo(0);
         assertThat(serverUrl).isEqualTo(app.service);
-        verify(app.registryApiClient).addParticipant(isA(Participant.class));
-        assertThat(participantArgCaptor.getValue())
-                .usingRecursiveComparison().isEqualTo(participant1);
+        verify(app.registryApiClient).addParticipant(idsUrl);
     }
 
-    @Test
-    void invalidRequest_Add_Failure() throws Exception {
-        var request = "Invalid json";
+    private int executeParticipantsAdd(String idsUrl) {
+        return cmd.execute(
+                "-d", "did:web:did-server:test-authority",
+                "-k", "../rest-client/src/test/resources/private_p256.pem",
+                "-s", serverUrl,
+                "participants", "add",
+                "--ids-url", idsUrl);
+    }
 
-        var exitCode = cmd.execute("-s", serverUrl, "participants", "add", "--request", request);
-
-        assertThat(exitCode).isNotEqualTo(0);
-        assertThat(serverUrl).isEqualTo(app.service);
+    private int executeParticipantsAdd() {
+        return cmd.execute(
+                "-d", "did:web:did-server:test-authority",
+                "-k", "../rest-client/src/test/resources/private_p256.pem",
+                "-s", serverUrl,
+                "participants", "list");
     }
 }

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
@@ -42,6 +42,7 @@ class ParticipantsCommandTest {
     Participant participant2 = createParticipant();
     String serverUrl = FAKER.internet().url();
     String idsUrl = FAKER.internet().url();
+    String did = FAKER.internet().url();
 
     RegistrationServiceCli app = new RegistrationServiceCli();
     CommandLine cmd = new CommandLine(app);
@@ -76,13 +77,12 @@ class ParticipantsCommandTest {
 
         assertThat(exitCode).isEqualTo(0);
         assertThat(serverUrl).isEqualTo(app.service);
-        verify(app.registryApiClient).addParticipant(idsUrl);
+        verify(app.registryApiClient).addParticipant(did, idsUrl);
     }
 
     private int executeParticipantsAdd(String idsUrl) {
         return cmd.execute(
-                "-d", "did:web:did-server:test-authority",
-                "-k", "../rest-client/src/test/resources/private_p256.pem",
+                "-d", did,
                 "-s", serverUrl,
                 "participants", "add",
                 "--ids-url", idsUrl);
@@ -90,8 +90,7 @@ class ParticipantsCommandTest {
 
     private int executeParticipantsAdd() {
         return cmd.execute(
-                "-d", "did:web:did-server:test-authority",
-                "-k", "../rest-client/src/test/resources/private_p256.pem",
+                "-d", did,
                 "-s", serverUrl,
                 "participants", "list");
     }

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
@@ -77,7 +77,7 @@ class ParticipantsCommandTest {
 
         assertThat(exitCode).isEqualTo(0);
         assertThat(serverUrl).isEqualTo(app.service);
-        verify(app.registryApiClient).addParticipant(did, idsUrl);
+        verify(app.registryApiClient).addParticipant(idsUrl, did);
     }
 
     private int executeParticipantsAdd(String idsUrl) {

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
@@ -60,7 +60,7 @@ class ParticipantsCommandTest {
         when(app.registryApiClient.listParticipants())
                 .thenReturn(participants);
 
-        var exitCode = executeParticipantsAdd();
+        var exitCode = executeParticipantsList();
         assertThat(exitCode).isEqualTo(0);
         assertThat(serverUrl).isEqualTo(app.service);
 
@@ -88,7 +88,7 @@ class ParticipantsCommandTest {
                 "--ids-url", idsUrl);
     }
 
-    private int executeParticipantsAdd() {
+    private int executeParticipantsList() {
         return cmd.execute(
                 "-d", did,
                 "-s", serverUrl,

--- a/extensions/dataspace-authority-spi/src/main/java/org/eclipse/dataspaceconnector/registration/authority/model/Participant.java
+++ b/extensions/dataspace-authority-spi/src/main/java/org/eclipse/dataspaceconnector/registration/authority/model/Participant.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static java.lang.String.format;
 import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.AUTHORIZED;
@@ -30,10 +31,15 @@ import static org.eclipse.dataspaceconnector.registration.authority.model.Partic
 
 /**
  * Dataspace participant.
+ * <p>
+ * In a future version, the {@link #name}, {@link #url} and {@link #supportedProtocols} fields will be removed,
+ * as the {@link #did} provides sufficient information to identify the participant, and additional
+ * information can be retrieved from the participant's DID document.
  */
 @JsonDeserialize(builder = Participant.Builder.class)
 public class Participant {
 
+    private String did;
     private String name;
     private String url;
     private List<String> supportedProtocols = new ArrayList<>();
@@ -42,14 +48,21 @@ public class Participant {
     private Participant() {
     }
 
+    @Deprecated
     public String getName() {
         return name;
     }
 
+    @Deprecated
     public String getUrl() {
         return url;
     }
 
+    public String getDid() {
+        return did;
+    }
+
+    @Deprecated
     public List<String> getSupportedProtocols() {
         return Collections.unmodifiableList(supportedProtocols);
     }
@@ -110,6 +123,12 @@ public class Participant {
             return this;
         }
 
+        public Builder did(String did) {
+            participant.did = did;
+            return this;
+        }
+
+
         public Builder name(String name) {
             participant.name = name;
             return this;
@@ -121,6 +140,7 @@ public class Participant {
         }
 
         public Participant build() {
+            Objects.requireNonNull(participant.did, "did");
             return participant;
         }
     }

--- a/extensions/dataspace-authority-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/registration/TestUtils.java
+++ b/extensions/dataspace-authority-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/registration/TestUtils.java
@@ -28,6 +28,7 @@ public class TestUtils {
 
     public static Participant.Builder createParticipant() {
         return Participant.Builder.newInstance()
+                .did(FAKER.internet().url())
                 .status(FAKER.options().option(ParticipantStatus.class))
                 .name(FAKER.lorem().characters())
                 .url(FAKER.internet().url())

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -23,15 +23,9 @@ import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.dataspaceconnector.registration.authority.model.Participant;
 
 import java.util.List;
-import java.util.Objects;
-
-import static org.eclipse.dataspaceconnector.registration.auth.DidJwtAuthenticationFilter.CALLER_DID_HEADER;
-
 
 /**
  * Registration Service API controller to manage dataspace participants.
@@ -43,6 +37,8 @@ import static org.eclipse.dataspaceconnector.registration.auth.DidJwtAuthenticat
 public class RegistrationApiController {
 
     private static final String TEMPORARY_IDS_URL_HEADER = "IdsUrl";
+
+    private static final String CALLER_DID_HEADER = "CallerDid";
 
     private final RegistrationService service;
 
@@ -68,9 +64,8 @@ public class RegistrationApiController {
     @ApiResponse(responseCode = "204", description = "No content")
     @POST
     public void addParticipant(
-            @HeaderParam(TEMPORARY_IDS_URL_HEADER) String idsUrl, @Context HttpHeaders headers) {
-        var issuer = Objects.requireNonNull(headers.getHeaderString(CALLER_DID_HEADER));
-
-        service.addParticipant(issuer, idsUrl);
+            @HeaderParam(TEMPORARY_IDS_URL_HEADER) String idsUrl,
+            @HeaderParam(CALLER_DID_HEADER) String did) {
+        service.addParticipant(did, idsUrl);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -19,12 +19,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import org.eclipse.dataspaceconnector.registration.authority.model.Participant;
 
 import java.util.List;
+import java.util.Objects;
+
+import static org.eclipse.dataspaceconnector.registration.auth.DidJwtAuthenticationFilter.CALLER_DID_HEADER;
+
 
 /**
  * Registration Service API controller to manage dataspace participants.
@@ -34,6 +41,8 @@ import java.util.List;
 @Consumes({ "application/json" })
 @Path("/registry")
 public class RegistrationApiController {
+
+    private static final String TEMPORARY_IDS_URL_HEADER = "IdsUrl";
 
     private final RegistrationService service;
 
@@ -58,7 +67,10 @@ public class RegistrationApiController {
     @Operation(description = "Asynchronously request to add a dataspace participant.")
     @ApiResponse(responseCode = "204", description = "No content")
     @POST
-    public void addParticipant(Participant participant) {
-        service.addParticipant(participant);
+    public void addParticipant(
+            @HeaderParam(TEMPORARY_IDS_URL_HEADER) String idsUrl, @Context HttpHeaders headers) {
+        var issuer = Objects.requireNonNull(headers.getHeaderString(CALLER_DID_HEADER));
+
+        service.addParticipant(issuer, idsUrl);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationApiController.java
@@ -36,8 +36,14 @@ import java.util.List;
 @Path("/registry")
 public class RegistrationApiController {
 
+    /**
+     * A IDS URL (this will be removed in https://github.com/agera-edc/MinimumViableDataspace/issues/174)
+     */
     private static final String TEMPORARY_IDS_URL_HEADER = "IdsUrl";
 
+    /**
+     * A DID that identifies the caller (in the next PR to the same branch, this will be removed from operation parameters and extracted from the passed JWT. This is only here as a stopgap to make PRs smaller)
+     */
     private static final String CALLER_DID_HEADER = "CallerDid";
 
     private final RegistrationService service;

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/api/RegistrationService.java
@@ -21,6 +21,8 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.eclipse.dataspaceconnector.registration.authority.model.ParticipantStatus.ONBOARDING_INITIATED;
+
 /**
  * Registration service for dataspace participants.
  */
@@ -46,11 +48,25 @@ public class RegistrationService {
 
     /**
      * Add a participant to a dataspace.
+     * <p>
+     * In a future version, the {@code idsUrl} argument will be removed, as the {@code did}
+     * provides sufficient information to identify the participant, and the
+     * Registration Service will not manage service URLs.
      *
-     * @param participant the dataspace participant to add.
+     * @param did    the DID of the dataspace participant to add.
+     * @param idsUrl the IDS URL of the dataspace participant to add.
      */
-    public void addParticipant(Participant participant) {
+    public void addParticipant(String did, String idsUrl) {
         monitor.info("Adding a participant in the dataspace.");
+
+        var participant = Participant.Builder.newInstance()
+                .did(did)
+                .status(ONBOARDING_INITIATED)
+                .name(did)
+                .url(idsUrl)
+                .supportedProtocol("ids-multipart")
+                .build();
+
         participantStore.save(participant);
     }
 }

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/store/InMemoryParticipantStore.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/store/InMemoryParticipantStore.java
@@ -39,7 +39,7 @@ public class InMemoryParticipantStore implements ParticipantStore {
 
     @Override
     public void save(Participant participant) {
-        storage.put(participant.getName(), participant);
+        storage.put(participant.getDid(), participant);
     }
 
     @Override

--- a/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/store/InMemoryParticipantStoreTest.java
+++ b/extensions/registration-service/src/test/java/org/eclipse/dataspaceconnector/registration/store/InMemoryParticipantStoreTest.java
@@ -26,7 +26,7 @@ class InMemoryParticipantStoreTest {
 
     InMemoryParticipantStore store = new InMemoryParticipantStore();
     Participant participant1 = TestUtils.createParticipant().build();
-    Participant participant1OtherEntry = TestUtils.createParticipant().name(participant1.getName()).build();
+    Participant participant1OtherEntry = TestUtils.createParticipant().did(participant1.getDid()).build();
     Participant participant2 = TestUtils.createParticipant().build();
 
     @Test

--- a/resources/openapi/yaml/registration-service.yaml
+++ b/resources/openapi/yaml/registration-service.yaml
@@ -7,11 +7,15 @@ paths:
     post:
       description: Asynchronously request to add a dataspace participant.
       operationId: addParticipant
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Participant'
+      parameters:
+      - in: header
+        name: IdsUrl
+        schema:
+          type: string
+      - in: header
+        name: CallerDid
+        schema:
+          type: string
       responses:
         "204":
           description: No content
@@ -37,6 +41,8 @@ components:
     Participant:
       type: object
       properties:
+        did:
+          type: string
         name:
           type: string
         status:

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -14,29 +14,32 @@
 
 package org.eclipse.dataspaceconnector.registration.client;
 
+import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.registration.client.api.RegistryApi;
-import org.eclipse.dataspaceconnector.registration.client.models.Participant;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.registration.client.IntegrationTestUtils.createParticipant;
 
 @IntegrationTest
 public class RegistrationApiClientTest {
     static final String API_URL = "http://localhost:8181/api";
+    static final Faker FAKER = new Faker();
 
     ApiClient apiClient = ApiClientFactory.createApiClient(API_URL);
     RegistryApi api = new RegistryApi(apiClient);
-    Participant participant = createParticipant();
+
+    String did = FAKER.internet().url();
+    String participantUrl = FAKER.internet().url();
 
     @Test
     void listParticipants() {
-        assertThat(api.listParticipants())
-                .doesNotContain(participant);
-
-        api.addParticipant(participant);
 
         assertThat(api.listParticipants())
-                .contains(participant);
+                .noneSatisfy(p -> assertThat(p.getUrl()).isEqualTo(participantUrl));
+
+        api.addParticipant(participantUrl, did);
+
+        assertThat(api.listParticipants())
+                .anySatisfy(p -> assertThat(p.getUrl()).isEqualTo(participantUrl));
     }
 }

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.registration.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.registration.cli.RegistrationServiceCli;
 import org.eclipse.dataspaceconnector.registration.client.models.Participant;
 import org.junit.jupiter.api.Test;
@@ -27,33 +28,32 @@ import java.io.StringWriter;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.dataspaceconnector.registration.client.IntegrationTestUtils.createParticipant;
 
 @IntegrationTest
 public class RegistrationApiCommandLineClientTest {
-    static final String API_URL = "http://localhost:8181/api";
-
     static final ObjectMapper MAPPER = new ObjectMapper();
-    Participant participant = createParticipant();
+    static final Faker FAKER = new Faker();
+    String did = FAKER.internet().url();
+    String idsUrl = FAKER.internet().url();
 
     @Test
     void listParticipants() throws Exception {
         CommandLine cmd = RegistrationServiceCli.getCommandLine();
 
-        assertThat(getParticipants(cmd)).doesNotContain(participant);
-
-        var request = MAPPER.writeValueAsString(participant);
-
-        var addCmdExitCode = cmd.execute("-s", API_URL, "participants", "add", "--request", request);
+        var addCmdExitCode = cmd.execute(
+                "-d", did,
+                "participants", "add",
+                "--ids-url", idsUrl);
         assertThat(addCmdExitCode).isEqualTo(0);
-        assertThat(getParticipants(cmd)).contains(participant);
+        assertThat(getParticipants(cmd)).anySatisfy(p -> assertThat(p.getUrl()).isEqualTo(idsUrl));
     }
 
     private List<Participant> getParticipants(CommandLine cmd) throws JsonProcessingException {
         var writer = new StringWriter();
         cmd.setOut(new PrintWriter(writer));
-        var listCmdExitCode = cmd.execute("participants", "list");
-
+        var listCmdExitCode = cmd.execute(
+                "-d", did,
+                "participants", "list");
         assertThat(listCmdExitCode).isEqualTo(0);
 
         var output = writer.toString();

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -40,9 +40,7 @@ public class RegistrationApiCommandLineClientTest {
     void listParticipants() throws Exception {
         CommandLine cmd = RegistrationServiceCli.getCommandLine();
 
-        assertThat(getParticipants(cmd)).doesNotContain(participant);
-
-        var request = MAPPER.writeValueAsString(participant);
+        assertThat(getParticipants(cmd)).noneSatisfy(p -> assertThat(p.getUrl()).isEqualTo(idsUrl));
 
         var addCmdExitCode = cmd.execute(
                 "-d", did,


### PR DESCRIPTION
## What this PR changes/adds

This is an intermediate PR for Registry Service JWS validation (https://github.com/agera-edc/MinimumViableDataspace/issues/14).

Added a `did` property in the `Participant` entity.

Changed the Add Participant REST operation controller to accept an empty body, and two headers:
- A IDS URL (this will be removed in https://github.com/agera-edc/MinimumViableDataspace/issues/174)
- A DID that identifies the caller (in the next PR to the same branch, this will be removed from operation parameters and extracted from the passed JWT. This is only here as a stopgap to make PRs smaller)

## Why it does that

As part of https://github.com/agera-edc/MinimumViableDataspace/issues/14, it only makes sense to validate the caller DID if the DID is actually used to populate the participant record.

The Add Participant REST operation was allowing the caller to define the state machine state of the created entity. This should not happen, therefore we are restricting inputs.

## Further notes

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/14

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
