### PR TITLE
Feature/14/14 web context (with ADR)

### DIFF
--- a/client-cli/README.md
+++ b/client-cli/README.md
@@ -16,7 +16,7 @@ For example, to list dataspace participants:
 
 ```
 java -jar client-cli/build/libs/registration-service-cli.jar \
-  -s=http://localhost:8181/api \
+  -s=http://localhost:8182/authority \
   participants list
 ```
 

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
@@ -25,7 +25,7 @@ import picocli.CommandLine.Command;
                 ParticipantsCommand.class
         })
 public class RegistrationServiceCli {
-    @CommandLine.Option(names = "-s", required = true, description = "Registration service URL", defaultValue = "http://localhost:8181/api")
+    @CommandLine.Option(names = "-s", required = true, description = "Registration service URL", defaultValue = "http://localhost:8182/authority")
     String service;
 
     RegistryApi registryApiClient;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         JVM_ARGS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"
     environment:
       EDC_API_AUTH_KEY: ApiKeyDefaultValue
+      WEB_HTTP_AUTHORITY_PORT: 8182
+      WEB_HTTP_AUTHORITY_PATH: /authority
     ports:
-      - "8181:8181"
+      - "8182:8182"
       - "5005:5005"

--- a/docs/developer/decision-records/2022-06-29-http-ports/README.md
+++ b/docs/developer/decision-records/2022-06-29-http-ports/README.md
@@ -1,0 +1,27 @@
+# HTTP Ports
+
+## Decision
+
+The EDC `default` web context is deployed on HTTP port `8181`. This context contains the health endpoint at `http://localhost:8181/api/check/health`.
+
+The Registration Service REST Controller is deployed in a additional EDC web context named `authority`.
+
+The port mapping and REST URL path for this context must be specified in deployment.
+
+For example in Docker Compose:
+
+```
+    environment:
+      WEB_HTTP_AUTHORITY_PORT: 8182
+      WEB_HTTP_AUTHORITY_PATH: /authority
+```
+
+This makes the List Participants endpoint available at `http://localhost:8182/authority/registry/participants`.
+
+## Rationale
+
+DID-based JWS authentication will be used for the Registration Service controller, using a JAX-RS filter.
+
+However, for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we will want to apply our authentication filter to the default context.
+
+It is also good practice not to expose health and management endpoints to public API.

--- a/docs/developer/decision-records/2022-06-29-http-ports/README.md
+++ b/docs/developer/decision-records/2022-06-29-http-ports/README.md
@@ -24,4 +24,4 @@ DID-based JWS authentication will be used for the Registration Service controlle
 
 However, for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we do not want to apply our authentication filter to the `default` context, and need to introduce an additional context for the API controller.
 
-It is also good practice not to expose health and management endpoints to public API.
+It is also good practice not to expose health and management endpoints to public access. Deploying them on a different ports allow deployments to expose their port on internal routes only.

--- a/docs/developer/decision-records/2022-06-29-http-ports/README.md
+++ b/docs/developer/decision-records/2022-06-29-http-ports/README.md
@@ -22,6 +22,6 @@ This makes the List Participants endpoint available at `http://localhost:8182/au
 
 DID-based JWS authentication will be used for the Registration Service controller, using a JAX-RS filter.
 
-However, for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we will want to apply our authentication filter to the default context.
+However, for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC default context. Therefore, we do not want to apply our authentication filter to the `default` context, and need to introduce an additional context for the API controller.
 
 It is also good practice not to expose health and management endpoints to public API.

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/RegistrationServiceExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/RegistrationServiceExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.dataspaceconnector.registration.manager.ParticipantManager;
 import org.eclipse.dataspaceconnector.registration.store.InMemoryParticipantStore;
 import org.eclipse.dataspaceconnector.registration.store.spi.ParticipantStore;
 import org.eclipse.dataspaceconnector.spi.WebService;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.ExecutorInstrumentation;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provider;

--- a/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/RegistrationServiceExtension.java
+++ b/extensions/registration-service/src/main/java/org/eclipse/dataspaceconnector/registration/RegistrationServiceExtension.java
@@ -33,6 +33,11 @@ import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
  */
 public class RegistrationServiceExtension implements ServiceExtension {
 
+    public static final String CONTEXT_ALIAS = "authority";
+
+    @Inject
+    private Monitor monitor;
+
     @Inject
     private WebService webService;
 
@@ -49,12 +54,11 @@ public class RegistrationServiceExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var monitor = context.getMonitor();
 
         participantManager = new ParticipantManager(monitor, participantStore, credentialsVerifier, executorInstrumentation);
 
         var registrationService = new RegistrationService(monitor, participantStore);
-        webService.registerResource(new RegistrationApiController(registrationService));
+        webService.registerResource(CONTEXT_ALIAS, new RegistrationApiController(registrationService));
     }
 
     @Override

--- a/launcher/Dockerfile
+++ b/launcher/Dockerfile
@@ -12,10 +12,10 @@ RUN apt update \
 WORKDIR /app
 COPY ./build/libs/app.jar /app
 
-EXPOSE 8181
+EXPOSE 8182
 
 # health status is determined by the availability of the /health endpoint
-HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl -H "X-Api-Key: $EDC_API_AUTH_KEY" --fail http://localhost:8181/api/check/health
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD curl --fail http://localhost:8181/api/check/health
 
 ENV WEB_HTTP_PORT="8181"
 ENV WEB_HTTP_PATH="/api"

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiClientTest.java
@@ -23,7 +23,7 @@ import static org.eclipse.dataspaceconnector.registration.client.IntegrationTest
 
 @IntegrationTest
 public class RegistrationApiClientTest {
-    static final String API_URL = "http://localhost:8181/api";
+    static final String API_URL = "http://localhost:8182/authority";
 
     ApiClient apiClient = ApiClientFactory.createApiClient(API_URL);
     RegistryApi api = new RegistryApi(apiClient);

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -31,8 +31,6 @@ import static org.eclipse.dataspaceconnector.registration.client.IntegrationTest
 
 @IntegrationTest
 public class RegistrationApiCommandLineClientTest {
-    static final String API_URL = "http://localhost:8181/api";
-
     static final ObjectMapper MAPPER = new ObjectMapper();
     Participant participant = createParticipant();
 
@@ -44,7 +42,7 @@ public class RegistrationApiCommandLineClientTest {
 
         var request = MAPPER.writeValueAsString(participant);
 
-        var addCmdExitCode = cmd.execute("-s", API_URL, "participants", "add", "--request", request);
+        var addCmdExitCode = cmd.execute("participants", "add", "--request", request);
         assertThat(addCmdExitCode).isEqualTo(0);
         assertThat(getParticipants(cmd)).contains(participant);
     }


### PR DESCRIPTION
## What this PR changes/adds

This is an intermediate PR for Registry Service JWS validation (https://github.com/agera-edc/MinimumViableDataspace/issues/14).

Deploys the Registration Service controller to a custom Jersey context (port mapping), rather than the EDC `default` context.

## Why it does that

In the next PR we want to enforce JWS authentication for the Registration Service controller, using a JAX-RS filter.

However for docker health check (used in `docker-compose up --wait` in CI to wait until containers have successfully started), we use `curl` to access the health endpoint, which is deployed in the EDC `default` context. Therefere, we will want to apply our JWS authentication filter to the `default` context.

It is anyway good practice not to expose health and management endpoints to public API.

## Further notes

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/14

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
