### PR TITLE
[RegistrationService CLI] Remove deprecated --service option

### DIFF
--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
@@ -40,7 +40,7 @@ public class RegistrationServiceCli {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-    @CommandLine.Option(names = { "-d", "--dataspace-did" }, description = "Dataspace Authority DID.", defaultValue = "")
+    @CommandLine.Option(names = { "-d", "--dataspace-did" }, required = true, description = "Dataspace Authority DID.")
     String dataspaceDid;
 
     @CommandLine.Option(names = { "-c", "--client-did" }, required = true, description = "Client DID.")

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationServiceCli.java
@@ -40,10 +40,6 @@ public class RegistrationServiceCli {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
-    @Deprecated
-    @CommandLine.Option(names = "-s", description = "Registration service URL. Deprecated. Use -d instead.", defaultValue = "http://localhost:8182/authority")
-    String service;
-
     @CommandLine.Option(names = { "-d", "--dataspace-did" }, description = "Dataspace Authority DID.", defaultValue = "")
     String dataspaceDid;
 
@@ -83,13 +79,6 @@ public class RegistrationServiceCli {
             privateKeyData = Files.readString(privateKeyFile);
         } catch (IOException e) {
             throw new RuntimeException("Error reading file " + privateKeyFile, e);
-        }
-
-        // TODO: temporary to preserve the backwards compatibility (https://github.com/agera-edc/MinimumViableDataspace/issues/174)
-        if (dataspaceDid.isEmpty()) {
-            var apiClient = createApiClient(service, clientDid, privateKeyData);
-            this.registryApiClient = new RegistryApi(apiClient);
-            return;
         }
 
         registryApiClient = new RegistryApi(createApiClient(registrationUrl(), clientDid, privateKeyData));

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationUrlResolver.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/registration/cli/RegistrationUrlResolver.java
@@ -50,5 +50,4 @@ public class RegistrationUrlResolver {
                 .map(Result::success)
                 .orElse(Result.failure("Error resolving service endpoint from DID Document for " + did));
     }
-
 }

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/registration/cli/ParticipantsCommandTest.java
@@ -46,7 +46,6 @@ class ParticipantsCommandTest {
 
     Participant participant1 = createParticipant();
     Participant participant2 = createParticipant();
-    String serverUrl = FAKER.internet().url();
     String idsUrl = FAKER.internet().url();
     String clientDid = FAKER.internet().url();
     String dataspaceDid = "did:web:" + FAKER.internet().domainName();
@@ -82,41 +81,6 @@ class ParticipantsCommandTest {
     void add() {
         var exitCode = executeParticipantsAdd("-d", dataspaceDid);
         assertAddParticipants(exitCode, dataspaceDid, app.dataspaceDid);
-    }
-
-    @Deprecated
-    @Test
-    void list_using_serviceUrl() throws Exception {
-        var participants = List.of(this.participant1, participant2);
-        when(app.registryApiClient.listParticipants())
-                .thenReturn(participants);
-
-        var exitCode = executeParticipantsList("-s", serverUrl);
-        assertListParticipants(participants, exitCode, app.service, serverUrl);
-    }
-
-    @Deprecated
-    @Test
-    void add_using_serviceUrl() {
-        var exitCode = executeParticipantsAdd("-s", serverUrl);
-        assertAddParticipants(exitCode, serverUrl, app.service);
-    }
-
-    @Deprecated
-    @Test
-    void add_both_inputs() {
-        var exitCode = cmd.execute(
-                "-c", clientDid,
-                "-k", privateKeyFile.toString(),
-                "-s", serverUrl,
-                "-d", dataspaceDid,
-                "participants", "add",
-                "--ids-url", idsUrl);
-
-        assertThat(exitCode).isEqualTo(0);
-        assertThat(dataspaceDid).isEqualTo(app.dataspaceDid);
-        assertThat(serverUrl).isEqualTo(app.service);
-        verify(app.registryApiClient).addParticipant(idsUrl);
     }
 
     private void assertAddParticipants(int exitCode, String serverUrl, String service) {

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -65,23 +65,6 @@ public class RegistrationApiCommandLineClientTest {
         assertThat(getParticipants(cmd)).anySatisfy(p -> assertThat(p.getUrl()).isEqualTo(idsUrl));
     }
 
-    @Deprecated
-    @Test
-    void listParticipants_usingServiceUrl() throws Exception {
-        CommandLine cmd = RegistrationServiceCli.getCommandLine();
-
-        assertThat(getParticipants(cmd)).noneSatisfy(p -> assertThat(p.getUrl()).isEqualTo(idsUrl));
-
-        var addCmdExitCode = cmd.execute(
-                "-c", CLIENT_DID_WEB,
-                "-k", privateKeyFile.toString(),
-                "--http-scheme",
-                "participants", "add",
-                "--ids-url", idsUrl);
-        assertThat(addCmdExitCode).isEqualTo(0);
-        assertThat(getParticipants(cmd)).anySatisfy(p -> assertThat(p.getUrl()).isEqualTo(idsUrl));
-    }
-
     private List<Participant> getParticipants(CommandLine cmd) throws JsonProcessingException {
         var writer = new StringWriter();
         cmd.setOut(new PrintWriter(writer));

--- a/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
+++ b/system-tests/src/test/java/org/eclipse/dataspaceconnector/registration/client/RegistrationApiCommandLineClientTest.java
@@ -70,7 +70,9 @@ public class RegistrationApiCommandLineClientTest {
         cmd.setOut(new PrintWriter(writer));
         var listCmdExitCode = cmd.execute(
                 "-c", CLIENT_DID_WEB,
+                "-d", DATASPACE_DID_WEB,
                 "-k", privateKeyFile.toString(),
+                "--http-scheme",
                 "participants", "list");
         assertThat(listCmdExitCode).isEqualTo(0);
 


### PR DESCRIPTION
## What this PR changes/adds

Remove deprecated --service option

## Why it does that

Clean up after adding -d option to Registration Service CLI

## Linked Issue(s)

Linked to https://github.com/agera-edc/MinimumViableDataspace/issues/43

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
