### PR TITLE
Configure connect and read timeout for rest client

### DIFF
--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -19,6 +19,7 @@ import org.eclipse.dataspaceconnector.spi.iam.TokenRepresentation;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.Duration;
 import java.util.function.Function;
 
 /**
@@ -31,6 +32,7 @@ public class ApiClientFactory {
     /**
      * Create a new instance of {@link ApiClient} configured to access the given URL.
      * <p>
+     * Configured readTimeout is 30 seconds and connectTimeout is 10 seconds.
      * Note that the type of {@code credentialsProvider} is modeled on the EDC {@code IdentityService} interface, for easier integration.
      *
      * @param baseUri             API base URL.
@@ -40,6 +42,11 @@ public class ApiClientFactory {
     @NotNull
     public static ApiClient createApiClient(String baseUri, Function<TokenParameters, Result<TokenRepresentation>> credentialsProvider) {
         var apiClient = new ApiClient();
+        apiClient.setHttpClientBuilder(
+                apiClient.createDefaultHttpClientBuilder()
+                        .connectTimeout(Duration.ofSeconds(10))
+        );
+        apiClient.setReadTimeout(Duration.ofSeconds(30));
         apiClient.updateBaseUri(baseUri);
         apiClient.setRequestInterceptor(new JsonWebSignatureHeaderInterceptor(credentialsProvider, baseUri));
         return apiClient;

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -26,13 +26,17 @@ import java.util.function.Function;
  * Factory class for {@link ApiClient}.
  */
 public class ApiClientFactory {
+
+    private static final int API_CLIENT_CONNECT_TIMEOUT = Integer.parseInt(getEnv("API_CLIENT_CONNECT_TIMEOUT", "30"));
+    private static final int API_CLIENT_READ_TIMEOUT = Integer.parseInt(getEnv("API_CLIENT_READ_TIMEOUT", "60"));
+
     private ApiClientFactory() {
     }
 
     /**
      * Create a new instance of {@link ApiClient} configured to access the given URL.
      * <p>
-     * Configured readTimeout is 60 seconds and connectTimeout is 30 seconds.
+     * Configured readTimeout as env var API_CLIENT_READ_TIMEOUT and connectTimeout as env var API_CLIENT_CONNECT_TIMEOUT.
      * Note that the type of {@code credentialsProvider} is modeled on the EDC {@code IdentityService} interface, for easier integration.
      *
      * @param baseUri             API base URL.
@@ -44,11 +48,19 @@ public class ApiClientFactory {
         var apiClient = new ApiClient();
         apiClient.setHttpClientBuilder(
                 apiClient.createDefaultHttpClientBuilder()
-                        .connectTimeout(Duration.ofSeconds(30))
+                        .connectTimeout(Duration.ofSeconds(API_CLIENT_CONNECT_TIMEOUT))
         );
-        apiClient.setReadTimeout(Duration.ofSeconds(60));
+        apiClient.setReadTimeout(Duration.ofSeconds(API_CLIENT_READ_TIMEOUT));
         apiClient.updateBaseUri(baseUri);
         apiClient.setRequestInterceptor(new JsonWebSignatureHeaderInterceptor(credentialsProvider, baseUri));
         return apiClient;
+    }
+
+    private static String getEnv(String key, String defaultValue) {
+        String value = System.getenv(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        return value;
     }
 }

--- a/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
+++ b/rest-client/src/main/java/org/eclipse/dataspaceconnector/registration/client/ApiClientFactory.java
@@ -32,7 +32,7 @@ public class ApiClientFactory {
     /**
      * Create a new instance of {@link ApiClient} configured to access the given URL.
      * <p>
-     * Configured readTimeout is 30 seconds and connectTimeout is 10 seconds.
+     * Configured readTimeout is 60 seconds and connectTimeout is 30 seconds.
      * Note that the type of {@code credentialsProvider} is modeled on the EDC {@code IdentityService} interface, for easier integration.
      *
      * @param baseUri             API base URL.
@@ -44,9 +44,9 @@ public class ApiClientFactory {
         var apiClient = new ApiClient();
         apiClient.setHttpClientBuilder(
                 apiClient.createDefaultHttpClientBuilder()
-                        .connectTimeout(Duration.ofSeconds(10))
+                        .connectTimeout(Duration.ofSeconds(30))
         );
-        apiClient.setReadTimeout(Duration.ofSeconds(30));
+        apiClient.setReadTimeout(Duration.ofSeconds(60));
         apiClient.updateBaseUri(baseUri);
         apiClient.setRequestInterceptor(new JsonWebSignatureHeaderInterceptor(credentialsProvider, baseUri));
         return apiClient;


### PR DESCRIPTION
## What this PR changes/adds

Configure connect and read timeout for rest client. readTimeout is 60 seconds and connectTimeout is 30 seconds.

## Why it does that

It was observed that client calls didn't timeout which mean CI steps can be running until it reaches CI timeout limit. Which can be very high e.g. 1 hour. For example, see CI run here https://github.com/agera-edc/MinimumViableDataspace/runs/7874926981?check_suite_focus=true  which kept on running until cancelled manually.

## Linked Issue(s)

Relates to https://github.com/agera-edc/MinimumViableDataspace/issues/46

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/RegistrationService/blob/main/styleguide.md) for details_)
